### PR TITLE
UPSTREAM 88911: /readyz should start returning failure on shutdown initiation

### DIFF
--- a/pkg/server/genericapiserver.go
+++ b/pkg/server/genericapiserver.go
@@ -318,7 +318,13 @@ func (s preparedGenericAPIServer) Run(stopCh <-chan struct{}) error {
 
 	go func() {
 		defer close(delayedStopCh)
+
 		<-stopCh
+
+		// As soon as shutdown is initiated, /readyz should start returning failure.
+		// This gives the load balancer a window defined by ShutdownDelayDuration to detect that /readyz is red
+		// and stop sending traffic to this server.
+		close(s.readinessStopCh)
 
 		time.Sleep(s.ShutdownDelayDuration)
 	}()
@@ -379,7 +385,6 @@ func (s preparedGenericAPIServer) NonBlockingRun(stopCh <-chan struct{}) error {
 	// ensure cleanup.
 	go func() {
 		<-stopCh
-		close(s.readinessStopCh)
 		close(internalStopCh)
 		if stoppedCh != nil {
 			<-stoppedCh


### PR DESCRIPTION
Currently, /readyz starts reporting failure after ShutdownDelayDuration
elapses. We expect /readyz to start returning failure as soon as
shutdown is initiated. This gives the load balancer a window defined by
ShutdownDelayDuration to detect that /readyz is red and stop sending
traffic to this server.
