### PR TITLE
Bug 1814207: fixes configmap "extension-apiserver-authentication" not found

### DIFF
--- a/pkg/server/dynamiccertificates/configmap_cafile_content.go
+++ b/pkg/server/dynamiccertificates/configmap_cafile_content.go
@@ -97,10 +97,7 @@ func NewDynamicCAFromConfigMapController(purpose, namespace, name, key string, k
 		queue:        workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), fmt.Sprintf("DynamicConfigMapCABundle-%s", purpose)),
 		preRunCaches: []cache.InformerSynced{uncastConfigmapInformer.HasSynced},
 	}
-	if err := c.loadCABundle(); err != nil {
-		// don't fail, but do print out a message
-		klog.Warningf("unable to load initial CA bundle for: %q due to: %s", c.name, err)
-	}
+
 	uncastConfigmapInformer.AddEventHandler(cache.FilteringResourceEventHandler{
 		FilterFunc: func(obj interface{}) bool {
 			if cast, ok := obj.(*corev1.ConfigMap); ok {

--- a/pkg/server/dynamiccertificates/dynamic_cafile_content.go
+++ b/pkg/server/dynamiccertificates/dynamic_cafile_content.go
@@ -126,6 +126,7 @@ func (c *DynamicFileCAContent) loadCABundle() error {
 		return err
 	}
 	c.caBundle.Store(caBundleAndVerifier)
+	klog.V(2).Infof("Loaded a new CA Bundle and Verifier for %q", c.Name())
 
 	for _, listener := range c.listeners {
 		listener.Enqueue()

--- a/pkg/server/dynamiccertificates/static_content.go
+++ b/pkg/server/dynamiccertificates/static_content.go
@@ -19,8 +19,6 @@ package dynamiccertificates
 import (
 	"crypto/tls"
 	"crypto/x509"
-	"fmt"
-	"io/ioutil"
 )
 
 type staticCAContent struct {
@@ -29,19 +27,6 @@ type staticCAContent struct {
 }
 
 var _ CAContentProvider = &staticCAContent{}
-
-// NewStaticCAContentFromFile returns a CAContentProvider based on a filename
-func NewStaticCAContentFromFile(filename string) (CAContentProvider, error) {
-	if len(filename) == 0 {
-		return nil, fmt.Errorf("missing filename for ca bundle")
-	}
-
-	caBundle, err := ioutil.ReadFile(filename)
-	if err != nil {
-		return nil, err
-	}
-	return NewStaticCAContent(filename, caBundle)
-}
 
 // NewStaticCAContent returns a CAContentProvider that always returns the same value
 func NewStaticCAContent(name string, caBundle []byte) (CAContentProvider, error) {
@@ -79,48 +64,6 @@ type staticCertKeyContent struct {
 type staticSNICertKeyContent struct {
 	staticCertKeyContent
 	sniNames []string
-}
-
-// NewStaticCertKeyContentFromFiles returns a CertKeyContentProvider based on a filename
-func NewStaticCertKeyContentFromFiles(certFile, keyFile string) (CertKeyContentProvider, error) {
-	if len(certFile) == 0 {
-		return nil, fmt.Errorf("missing filename for certificate")
-	}
-	if len(keyFile) == 0 {
-		return nil, fmt.Errorf("missing filename for key")
-	}
-
-	certPEMBlock, err := ioutil.ReadFile(certFile)
-	if err != nil {
-		return nil, err
-	}
-	keyPEMBlock, err := ioutil.ReadFile(keyFile)
-	if err != nil {
-		return nil, err
-	}
-
-	return NewStaticCertKeyContent(fmt.Sprintf("cert: %s, key: %s", certFile, keyFile), certPEMBlock, keyPEMBlock)
-}
-
-// NewStaticSNICertKeyContentFromFiles returns a SNICertKeyContentProvider based on a filename
-func NewStaticSNICertKeyContentFromFiles(certFile, keyFile string, sniNames ...string) (SNICertKeyContentProvider, error) {
-	if len(certFile) == 0 {
-		return nil, fmt.Errorf("missing filename for certificate")
-	}
-	if len(keyFile) == 0 {
-		return nil, fmt.Errorf("missing filename for key")
-	}
-
-	certPEMBlock, err := ioutil.ReadFile(certFile)
-	if err != nil {
-		return nil, err
-	}
-	keyPEMBlock, err := ioutil.ReadFile(keyFile)
-	if err != nil {
-		return nil, err
-	}
-
-	return NewStaticSNICertKeyContent(fmt.Sprintf("cert: %s, key: %s", certFile, keyFile), certPEMBlock, keyPEMBlock, sniNames...)
 }
 
 // NewStaticCertKeyContent returns a CertKeyContentProvider that always returns the same value


### PR DESCRIPTION
makes errors like `configmap_cafile_content.go:102] unable to load initial CA bundle for: "client-ca::kube-system::extension-apiserver-authentication::client-ca-file" due to: configmap "extension-apiserver-authentication"` not found to go away at the server startup