### PR TITLE
fix filtering out CustomResourceQuota paths from OpenAPI

### DIFF
--- a/pkg/server/routes/openapi.go
+++ b/pkg/server/routes/openapi.go
@@ -17,8 +17,6 @@ limitations under the License.
 package routes
 
 import (
-	"strings"
-
 	restful "github.com/emicklei/go-restful"
 	"github.com/go-openapi/spec"
 	"k8s.io/klog/v2"
@@ -36,6 +34,17 @@ type OpenAPI struct {
 
 // Install adds the SwaggerUI webservice to the given mux.
 func (oa OpenAPI) Install(c *restful.Container, mux *mux.PathRecorderMux) (*handler.OpenAPIService, *spec.Swagger) {
+	// we shadow ClustResourceQuotas, RoleBindingRestrictions, and SecurityContextContstraints
+	// with a CRD. This loop removes all CRQ,RBR, SCC paths
+	// from the OpenAPI spec such that they don't conflict with the CRD
+	// apiextensions-apiserver spec during merging.
+	oa.Config.IgnorePrefixes = append(oa.Config.IgnorePrefixes,
+		"/apis/quota.openshift.io/v1/clusterresourcequotas",
+		"/apis/security.openshift.io/v1/securitycontextconstraints",
+		"/apis/authorization.openshift.io/v1/rolebindingrestrictions",
+		"/apis/authorization.openshift.io/v1/namespaces/{namespace}/rolebindingrestrictions",
+		"/apis/authorization.openshift.io/v1/watch/namespaces/{namespace}/rolebindingrestrictions",
+		"/apis/authorization.openshift.io/v1/watch/rolebindingrestrictions")
 	spec, err := builder.BuildOpenAPISpec(c.RegisteredWebServices(), oa.Config)
 	if err != nil {
 		klog.Fatalf("Failed to build open api spec for root: %v", err)
@@ -44,18 +53,6 @@ func (oa OpenAPI) Install(c *restful.Container, mux *mux.PathRecorderMux) (*hand
 	openAPIVersionedService, err := handler.NewOpenAPIService(spec)
 	if err != nil {
 		klog.Fatalf("Failed to create OpenAPIService: %v", err)
-	}
-
-	// we shadow ClustResourceQuotas, RoleBindingRestrictions, and SecurityContextContstraints
-	// with a CRD. This loop removes all CRQ,RBR, SCC paths
-	// from the OpenAPI spec such that they don't conflict with the CRD
-	// apiextensions-apiserver spec during merging.
-	for pth := range spec.Paths.Paths {
-		if strings.HasPrefix(pth, "/apis/quota.openshift.io/v1/clusterresourcequotas") ||
-			strings.Contains(pth, "rolebindingrestrictions") ||
-			strings.HasPrefix(pth, "/apis/security.openshift.io/v1/securitycontextconstraints") {
-			delete(spec.Paths.Paths, pth)
-		}
 	}
 
 	err = openAPIVersionedService.RegisterOpenAPIVersionedService("/openapi/v2", mux)


### PR DESCRIPTION
surprisingly removing the paths after the spec was built worked in the past.
with the upgrade to the new version the paths must be removed before building the spec.

the proof PR at https://github.com/openshift/openshift-apiserver/pull/132