### PR TITLE
UPSTREAM: <carry>: sets explicit timeout for SubjectAccessReview client

### DIFF
--- a/pkg/server/options/authorization.go
+++ b/pkg/server/options/authorization.go
@@ -186,6 +186,7 @@ func (s *DelegatingAuthorizationOptions) getClient() (kubernetes.Interface, erro
 	// set high qps/burst limits since this will effectively limit API server responsiveness
 	clientConfig.QPS = 200
 	clientConfig.Burst = 400
+	clientConfig.Timeout = 10 * time.Second
 
 	// make the client use protobuf
 	protoConfig := rest.CopyConfig(clientConfig)


### PR DESCRIPTION
previously no timeout was set. Requests without explicit timeout might potentially hang forever and lead to starvation of the application.

