### PR TITLE
Backports 96217, 95725, 95002 and 96424

### DIFF
--- a/pkg/endpoints/metrics/metrics.go
+++ b/pkg/endpoints/metrics/metrics.go
@@ -185,6 +185,17 @@ var (
 		},
 		[]string{"verb", "group", "version", "resource", "subresource", "scope", "component", "code"},
 	)
+
+	// requestAbortsTotal is a number of aborted requests with http.ErrAbortHandler
+	requestAbortsTotal = compbasemetrics.NewCounterVec(
+		&compbasemetrics.CounterOpts{
+			Name:           "apiserver_request_aborts_total",
+			Help:           "Number of requests which apiserver aborted possibly due to a timeout, for each group, version, verb, resource, subresource and scope",
+			StabilityLevel: compbasemetrics.ALPHA,
+		},
+		[]string{"verb", "group", "version", "resource", "subresource", "scope"},
+	)
+
 	kubectlExeRegexp = regexp.MustCompile(`^.*((?i:kubectl\.exe))`)
 
 	metrics = []resettableCollector{
@@ -201,6 +212,7 @@ var (
 		currentInflightRequests,
 		currentInqueueRequests,
 		requestTerminationsTotal,
+		requestAbortsTotal,
 	}
 
 	// these are the known (e.g. whitelisted/known) content types which we will report for
@@ -288,6 +300,22 @@ func UpdateInflightRequestMetrics(phase string, nonmutating, mutating int) {
 			currentInqueueRequests.WithLabelValues(kc.kind).Set(float64(kc.count))
 		}
 	}
+}
+
+// RecordRequestAbort records that the request was aborted possibly due to a timeout.
+func RecordRequestAbort(req *http.Request, requestInfo *request.RequestInfo) {
+	if requestInfo == nil {
+		requestInfo = &request.RequestInfo{Verb: req.Method, Path: req.URL.Path}
+	}
+
+	scope := CleanScope(requestInfo)
+	reportedVerb := cleanVerb(canonicalVerb(strings.ToUpper(req.Method), scope), req)
+	resource := requestInfo.Resource
+	subresource := requestInfo.Subresource
+	group := requestInfo.APIGroup
+	version := requestInfo.APIVersion
+
+	requestAbortsTotal.WithLabelValues(reportedVerb, group, version, resource, subresource, scope).Inc()
 }
 
 // RecordRequestTermination records that the request was terminated early as part of a resource

--- a/pkg/server/config.go
+++ b/pkg/server/config.go
@@ -765,7 +765,7 @@ func DefaultBuildHandlerChain(apiHandler http.Handler, c *Config) http.Handler {
 	handler = genericapifilters.WithAuditAnnotations(handler, c.AuditBackend, c.AuditPolicyChecker)
 	handler = genericapifilters.WithWarningRecorder(handler)
 	handler = genericapifilters.WithCacheControl(handler)
-	handler = genericfilters.WithPanicRecovery(handler)
+	handler = genericfilters.WithPanicRecovery(handler, c.RequestInfoResolver)
 	return handler
 }
 

--- a/pkg/server/filters/timeout.go
+++ b/pkg/server/filters/timeout.go
@@ -33,8 +33,6 @@ import (
 	apirequest "k8s.io/apiserver/pkg/endpoints/request"
 )
 
-var errConnKilled = fmt.Errorf("killing connection/stream because serving request timed out and response had been started")
-
 // WithTimeoutForNonLongRunningRequests times out non-long-running requests after the time given by timeout.
 func WithTimeoutForNonLongRunningRequests(handler http.Handler, longRunning apirequest.LongRunningRequestCheck, timeout time.Duration) http.Handler {
 	if longRunning == nil {
@@ -246,15 +244,17 @@ func (tw *baseTimeoutWriter) timeout(err *apierrors.StatusError) {
 		// no way to timeout the HTTP request at the point. We have to shutdown
 		// the connection for HTTP1 or reset stream for HTTP2.
 		//
-		// Note from: Brad Fitzpatrick
-		// if the ServeHTTP goroutine panics, that will do the best possible thing for both
-		// HTTP/1 and HTTP/2. In HTTP/1, assuming you're replying with at least HTTP/1.1 and
-		// you've already flushed the headers so it's using HTTP chunking, it'll kill the TCP
-		// connection immediately without a proper 0-byte EOF chunk, so the peer will recognize
-		// the response as bogus. In HTTP/2 the server will just RST_STREAM the stream, leaving
-		// the TCP connection open, but resetting the stream to the peer so it'll have an error,
-		// like the HTTP/1 case.
-		panic(errConnKilled)
+		// Note from the golang's docs:
+		// If ServeHTTP panics, the server (the caller of ServeHTTP) assumes
+		// that the effect of the panic was isolated to the active request.
+		// It recovers the panic, logs a stack trace to the server error log,
+		// and either closes the network connection or sends an HTTP/2
+		// RST_STREAM, depending on the HTTP protocol. To abort a handler so
+		// the client sees an interrupted response but the server doesn't log
+		// an error, panic with the value ErrAbortHandler.
+		//
+		// We are throwing http.ErrAbortHandler deliberately so that a client is notified and to suppress a not helpful stacktrace in the logs
+		panic(http.ErrAbortHandler)
 	}
 }
 

--- a/pkg/server/filters/timeout_test.go
+++ b/pkg/server/filters/timeout_test.go
@@ -244,8 +244,12 @@ func TestErrConnKilled(t *testing.T) {
 		t.Fatal("expected to receive an error")
 	}
 
+	// we should only get one line for this, not the big stack from before
 	capturedOutput := readStdErr()
-	if len(capturedOutput) > 0 {
+	if strings.Count(capturedOutput, "\n") != 1 {
+		t.Errorf("unexpected output captured actual = %v", capturedOutput)
+	}
+	if !strings.Contains(capturedOutput, `timeout or abort while handling: GET "/"`) {
 		t.Errorf("unexpected output captured actual = %v", capturedOutput)
 	}
 }
@@ -330,8 +334,12 @@ func TestErrConnKilledHTTP2(t *testing.T) {
 		t.Fatal("expected to receive an error")
 	}
 
+	// we should only get one line for this, not the big stack from before
 	capturedOutput := readStdErr()
-	if len(capturedOutput) > 0 {
+	if strings.Count(capturedOutput, "\n") != 1 {
+		t.Errorf("unexpected output captured actual = %v", capturedOutput)
+	}
+	if !strings.Contains(capturedOutput, `timeout or abort while handling: GET "/"`) {
 		t.Errorf("unexpected output captured actual = %v", capturedOutput)
 	}
 

--- a/pkg/server/filters/timeout_test.go
+++ b/pkg/server/filters/timeout_test.go
@@ -17,22 +17,34 @@ limitations under the License.
 package filters
 
 import (
+	"bytes"
+	"crypto/tls"
+	"crypto/x509"
 	"encoding/json"
 	"fmt"
+	"io"
 	"io/ioutil"
+	"net"
 	"net/http"
 	"net/http/httptest"
+	"net/http/httptrace"
+	"os"
 	"reflect"
 	"strings"
 	"sync"
 	"testing"
 	"time"
 
+	"golang.org/x/net/http2"
+
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/diff"
 	"k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/apiserver/pkg/endpoints/request"
+	"k8s.io/klog/v2"
 )
 
 type recorder struct {
@@ -175,3 +187,209 @@ func TestTimeout(t *testing.T) {
 		t.Fatalf("expected to see a handler panic, but didn't")
 	}
 }
+
+func captureStdErr() (func() string, func(), error) {
+	var buf bytes.Buffer
+	reader, writer, err := os.Pipe()
+	if err != nil {
+		return nil, nil, err
+	}
+	stderr := os.Stderr
+	readerClosedCh := make(chan struct{})
+	stopReadingStdErr := func() string {
+		writer.Close()
+		<-readerClosedCh
+		return buf.String()
+	}
+	klog.LogToStderr(true)
+	cleanUp := func() {
+		os.Stderr = stderr
+		klog.LogToStderr(false)
+		stopReadingStdErr()
+	}
+	os.Stderr = writer
+	go func() {
+		io.Copy(&buf, reader)
+		readerClosedCh <- struct{}{}
+		close(readerClosedCh)
+	}()
+	klog.LogToStderr(true)
+
+	return stopReadingStdErr, cleanUp, nil
+}
+
+func TestErrConnKilled(t *testing.T) {
+	readStdErr, cleanUp, err := captureStdErr()
+	if err != nil {
+		t.Fatalf("unable to setup the test, err %v", err)
+	}
+	defer cleanUp()
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// this error must be ignored by the WithPanicRecovery handler
+		// it is thrown by WithTimeoutForNonLongRunningRequests handler when a response has been already sent to the client and the handler timed out
+		// panicking with http.ErrAbortHandler also suppresses logging of a stack trace to the server's error log and closes the underlying connection
+		w.Write([]byte("hello from the handler"))
+		panic(http.ErrAbortHandler)
+	})
+	resolver := &request.RequestInfoFactory{
+		APIPrefixes:          sets.NewString("api", "apis"),
+		GrouplessAPIPrefixes: sets.NewString("api"),
+	}
+
+	ts := httptest.NewServer(WithPanicRecovery(handler, resolver))
+	defer ts.Close()
+
+	_, err = http.Get(ts.URL)
+	if err == nil {
+		t.Fatal("expected to receive an error")
+	}
+
+	capturedOutput := readStdErr()
+	if len(capturedOutput) > 0 {
+		t.Errorf("unexpected output captured actual = %v", capturedOutput)
+	}
+}
+
+type panicOnNonReuseTransport struct {
+	Transport   http.RoundTripper
+	gotConnSeen bool
+}
+
+func (t *panicOnNonReuseTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	return t.Transport.RoundTrip(req)
+}
+
+func (t *panicOnNonReuseTransport) GotConn(info httptrace.GotConnInfo) {
+	if !t.gotConnSeen {
+		t.gotConnSeen = true
+		return
+	}
+	if !info.Reused {
+		panic(fmt.Sprintf("expected the connection to be reused, info %#v", info))
+	}
+}
+
+// TestErrConnKilledHTTP2 check if HTTP/2 connection is not closed when an HTTP handler panics
+// The net/http library recovers the panic and sends an HTTP/2 RST_STREAM.
+func TestErrConnKilledHTTP2(t *testing.T) {
+	readStdErr, cleanUp, err := captureStdErr()
+	if err != nil {
+		t.Fatalf("unable to setup the test, err %v", err)
+	}
+	defer cleanUp()
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// this error must be ignored by the WithPanicRecovery handler
+		// it is thrown by WithTimeoutForNonLongRunningRequests handler when a response has been already sent to the client and the handler timed out
+		// panicking with http.ErrAbortHandler also suppresses logging of a stack trace to the server's error log and closes the underlying connection
+		w.Write([]byte("hello from the handler"))
+		panic(http.ErrAbortHandler)
+	})
+	resolver := &request.RequestInfoFactory{
+		APIPrefixes:          sets.NewString("api", "apis"),
+		GrouplessAPIPrefixes: sets.NewString("api"),
+	}
+
+	// test server
+	ts := httptest.NewUnstartedServer(WithPanicRecovery(handler, resolver))
+	tsCert, err := tls.X509KeyPair(tsCrt, tsKey)
+	if err != nil {
+		t.Fatalf("backend: invalid x509/key pair: %v", err)
+	}
+	ts.TLS = &tls.Config{
+		Certificates: []tls.Certificate{tsCert},
+		NextProtos:   []string{http2.NextProtoTLS},
+	}
+	ts.StartTLS()
+	defer ts.Close()
+
+	newServerRequest := func(tr *panicOnNonReuseTransport) *http.Request {
+		req, _ := http.NewRequest("GET", fmt.Sprintf("https://127.0.0.1:%d", ts.Listener.Addr().(*net.TCPAddr).Port), nil)
+		trace := &httptrace.ClientTrace{
+			GotConn: tr.GotConn,
+		}
+		return req.WithContext(httptrace.WithClientTrace(req.Context(), trace))
+	}
+
+	// client
+	clientCACertPool := x509.NewCertPool()
+	clientCACertPool.AppendCertsFromPEM(tsCrt)
+	clientTLSConfig := &tls.Config{
+		RootCAs:    clientCACertPool,
+		NextProtos: []string{http2.NextProtoTLS},
+	}
+	tr := &panicOnNonReuseTransport{}
+	client := &http.Client{}
+	tr.Transport = &http2.Transport{
+		TLSClientConfig: clientTLSConfig,
+	}
+	client.Transport = tr
+
+	// act
+	_, err = client.Do(newServerRequest(tr))
+	if err == nil {
+		t.Fatal("expected to receive an error")
+	}
+
+	capturedOutput := readStdErr()
+	if len(capturedOutput) > 0 {
+		t.Errorf("unexpected output captured actual = %v", capturedOutput)
+	}
+
+	// make another req to the server
+	// the connection should be reused
+	// the client uses a custom transport that checks and panics when the con wasn't reused.
+	_, err = client.Do(newServerRequest(tr))
+	if err == nil {
+		t.Fatal("expected to receive an error")
+	}
+}
+
+var tsCrt = []byte(`-----BEGIN CERTIFICATE-----
+MIIDTjCCAjagAwIBAgIJAJdcQEBN2CjoMA0GCSqGSIb3DQEBCwUAMFAxCzAJBgNV
+BAYTAlBMMQ8wDQYDVQQIDAZQb2xhbmQxDzANBgNVBAcMBkdkYW5zazELMAkGA1UE
+CgwCU0sxEjAQBgNVBAMMCWxvY2FsaG9zdDAeFw0yMDA5MjgxMTU1MjhaFw0zMDA5
+MjYxMTU1MjhaMFAxCzAJBgNVBAYTAlBMMQ8wDQYDVQQIDAZQb2xhbmQxDzANBgNV
+BAcMBkdkYW5zazELMAkGA1UECgwCU0sxEjAQBgNVBAMMCWxvY2FsaG9zdDCCASIw
+DQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAMr6b/uTHkIDEd88x3t3jnroOVwh
+jWMwZ6qXN2NV/If1L9FNvtoZzZi6yCDE1uLdD1kWZ0R2XOPEwUPn+Z8A/lg9kF8J
+GloLCF8q+XeYp8aWRKzwtdi+MPaKFf0wsuxEEHU4pypFrszNY0yLRbWAbMtgBFy0
+KhyNGahFO9V69cRHUj6EJ9kSBg0nG5bsypon2rinzKpUrzAEl2MbM3F34Zit5yOv
+rYQcbDME+9XmOJPD97XBvMZCbmPnmpst3tX7ZhdKgSKtIjoYt+d//wtPMXOhrRzM
+xcc6HuIHAovtB4kvZl5wvVU8ra8DKZviYyjfW36kQHo+yFwP3XXZFWezZi0CAwEA
+AaMrMCkwCQYDVR0TBAIwADALBgNVHQ8EBAMCBaAwDwYDVR0RBAgwBocEfwAAATAN
+BgkqhkiG9w0BAQsFAAOCAQEAMoAlhZ6yRwPmFL2ql9ZYWqaPu2NC4dXYV6kUIXUA
+pG3IqFWb3L4ePkgYBMDlJGpAJcXlSSgEGiLj+3qQojawIMzzxmqr2KX888S5Mr+9
+I1qseRwcftwYqV/ewJSWE90HJ21pb1ixA6bSRJLV7DyxO6zKsdVJ4xIvehZtGbux
+0RTf+8zUx8z2Goy1GUztOIqfMRt1P1hlQG0uvYsGQM84HO4+YhFwejrGaj8ajpgF
+uo3B8BVHeh57FNGE6C45NkFGHq3tkNLMdAa32Az8DDvPmsJuycf6vgIfBEQxLZSF
+OUKrKmtfdFv4XrInqFUYBYp5GkL8SGM2wmv6aSw9Aju4lA==
+-----END CERTIFICATE-----`)
+
+var tsKey = []byte(`-----BEGIN PRIVATE KEY-----
+MIIEvgIBADANBgkqhkiG9w0BAQEFAASCBKgwggSkAgEAAoIBAQDK+m/7kx5CAxHf
+PMd7d4566DlcIY1jMGeqlzdjVfyH9S/RTb7aGc2YusggxNbi3Q9ZFmdEdlzjxMFD
+5/mfAP5YPZBfCRpaCwhfKvl3mKfGlkSs8LXYvjD2ihX9MLLsRBB1OKcqRa7MzWNM
+i0W1gGzLYARctCocjRmoRTvVevXER1I+hCfZEgYNJxuW7MqaJ9q4p8yqVK8wBJdj
+GzNxd+GYrecjr62EHGwzBPvV5jiTw/e1wbzGQm5j55qbLd7V+2YXSoEirSI6GLfn
+f/8LTzFzoa0czMXHOh7iBwKL7QeJL2ZecL1VPK2vAymb4mMo31t+pEB6PshcD911
+2RVns2YtAgMBAAECggEAA2Qx0MtBeyrf9pHmZ1q1B7qvkqmA2kJpyQDjzQYXxRHE
+rcOVx8EcnUupolqHmJzG798e9JbhsHCOJhtPIWf71++XZO8bAJwklKp8JpJnYzsJ
+hLY0450x5jyiZ2uT4by1Za//owYtCID6AsJk9MZjivZcvEvKVFXLMvONL2DxkEj1
+KaGQJh6/GT4jtNX07bW9+5w069KAAf+BNuqv8+Y/FseV3ovlpLTKjMV9xCCp9i62
+PJs/hs5CW2X+JCE7OCLsAiu0JTpXYyHcLwYwnCONdvj6veiMWjRyNDr3ew5NeZNf
+nGU4WX7mXjPd/1OvzJy6iyrBlAA63ZfFZYjWQnfsIQKBgQDmo3AMIr+9rE79NnaD
+woQyO539YSO45KSM39/Xrp/NJVpOxtzgZrYo7O6f6kQ3S5zQOddy9Oj7gN3RXhZ7
+Vi+Oja78ig7KUrqxcBiBGRsKZGm5CGdZ0EFd3rIEh4Qb+f+2c4f+6NWANb4kwvfq
+K24c1o71+77lEVlzE2/L33K+mQKBgQDhTFr/f2e9gnRNX9bjF4p7DQI0RsFADjx0
+jgJYHfm/lCIdH9vf6SmmvJv2E76Bqx9XVilhav/egqKO/wzJWHyNo2RFBXNqfwoF
+UxRZKgqhcU52y2LKAYoTYfodktatZk74rinMDLmA6arnlAWQELk3Mx48DlND43Zc
+DUHTKcJEtQKBgQDYdL1c9mPjnEqJxMqXwEAXcPJG8hr3lMaGXDoVjxL1EsBdvK9h
+f6QoZq1RsiiRiMpEdnSotAfQutHzhA0vdeSuMnTvGJbm9Zu3mc+1oZ1KNJEwkh2F
+Ijmm4rFKJPEs3IVMc8NHzrdJW6b3k2/e+yGduRR08e7nx0+e+7fpq+1hyQKBgHY9
+l4h9+hkYjSdKhEG8yh3Ybu62r5eJoSremNZcLQXhnaHBZaj2+rgaRpP4OsRc5d71
+RlRtTood72iy7KgDO6MuPGKJANDEiaLPvl8pVFj0WWS5S0iPVELl6dl5hheNGSck
+aKVBjF3exKYzJlQ8oqgYuOZ18jcv+p9HCePkB6P9AoGBAJSYpkNDc/lnCpfIlxVw
+n+VroX6QDIMZzC7BGiUSrmVsu6xEbI+8/C7ecN2oCZZLMj96EXe6j+np4zmkQezc
+c1EwB7fNAiS0fWyE2RU6QAOZJ71bDpzQa4q4DxbOkYSybGPM/nqDRwovdjUnWeuM
++vrJUjAZAPHJcvos0iylnc8E
+-----END PRIVATE KEY-----`)

--- a/pkg/server/filters/wrap.go
+++ b/pkg/server/filters/wrap.go
@@ -17,22 +17,37 @@ limitations under the License.
 package filters
 
 import (
+	"k8s.io/apiserver/pkg/endpoints/request"
+	"k8s.io/klog/v2"
 	"net/http"
 
-	"k8s.io/klog/v2"
-
 	"k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/apiserver/pkg/endpoints/metrics"
 	"k8s.io/apiserver/pkg/server/httplog"
 )
 
 // WithPanicRecovery wraps an http Handler to recover and log panics (except in the special case of http.ErrAbortHandler panics, which suppress logging).
-func WithPanicRecovery(handler http.Handler) http.Handler {
+func WithPanicRecovery(handler http.Handler, resolver request.RequestInfoResolver) http.Handler {
 	return withPanicRecovery(handler, func(w http.ResponseWriter, req *http.Request, err interface{}) {
 		if err == http.ErrAbortHandler {
-			// honor the http.ErrAbortHandler sentinel panic value:
-			//   ErrAbortHandler is a sentinel panic value to abort a handler.
-			//   While any panic from ServeHTTP aborts the response to the client,
-			//   panicking with ErrAbortHandler also suppresses logging of a stack trace to the server's error log.
+			// Honor the http.ErrAbortHandler sentinel panic value
+			//
+			// If ServeHTTP panics, the server (the caller of ServeHTTP) assumes
+			// that the effect of the panic was isolated to the active request.
+			// It recovers the panic, logs a stack trace to the server error log,
+			// and either closes the network connection or sends an HTTP/2
+			// RST_STREAM, depending on the HTTP protocol. To abort a handler so
+			// the client sees an interrupted response but the server doesn't log
+			// an error, panic with the value ErrAbortHandler.
+			//
+			// Note that the ReallyCrash variable controls the behaviour of the HandleCrash function
+			// So it might actually crash, after calling the handlers
+			info, err := resolver.NewRequestInfo(req)
+			if err != nil {
+				metrics.RecordRequestAbort(req, nil)
+				return
+			}
+			metrics.RecordRequestAbort(req, info)
 			return
 		}
 		http.Error(w, "This request caused apiserver to panic. Look in the logs for details.", http.StatusInternalServerError)

--- a/pkg/server/filters/wrap.go
+++ b/pkg/server/filters/wrap.go
@@ -17,13 +17,14 @@ limitations under the License.
 package filters
 
 import (
-	"k8s.io/apiserver/pkg/endpoints/request"
-	"k8s.io/klog/v2"
+	"fmt"
 	"net/http"
 
 	"k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apiserver/pkg/endpoints/metrics"
+	"k8s.io/apiserver/pkg/endpoints/request"
 	"k8s.io/apiserver/pkg/server/httplog"
+	"k8s.io/klog/v2"
 )
 
 // WithPanicRecovery wraps an http Handler to recover and log panics (except in the special case of http.ErrAbortHandler panics, which suppress logging).
@@ -42,12 +43,15 @@ func WithPanicRecovery(handler http.Handler, resolver request.RequestInfoResolve
 			//
 			// Note that the ReallyCrash variable controls the behaviour of the HandleCrash function
 			// So it might actually crash, after calling the handlers
-			info, err := resolver.NewRequestInfo(req)
-			if err != nil {
+			if info, err := resolver.NewRequestInfo(req); err != nil {
 				metrics.RecordRequestAbort(req, nil)
-				return
+			} else {
+				metrics.RecordRequestAbort(req, info)
 			}
-			metrics.RecordRequestAbort(req, info)
+			// This call can have different handlers, but the default chain rate limits. Call it after the metrics are updated
+			// in case the rate limit delays it.  If you outrun the rate for this one timed out requests, something has gone
+			// seriously wrong with your server, but generally having a logging signal for timeouts is useful.
+			runtime.HandleError(fmt.Errorf("timeout or abort while handling: %v %q", req.Method, req.URL.Path))
 			return
 		}
 		http.Error(w, "This request caused apiserver to panic. Look in the logs for details.", http.StatusInternalServerError)

--- a/pkg/server/options/authentication.go
+++ b/pkg/server/options/authentication.go
@@ -177,6 +177,10 @@ type DelegatingAuthenticationOptions struct {
 	// TolerateInClusterLookupFailure indicates failures to look up authentication configuration from the cluster configmap should not be fatal.
 	// Setting this can result in an authenticator that will reject all requests.
 	TolerateInClusterLookupFailure bool
+
+	// ClientTimeout specifies a time limit for requests made by the authorization webhook client.
+	// The default value is set to 10 seconds.
+	ClientTimeout time.Duration
 }
 
 func NewDelegatingAuthenticationOptions() *DelegatingAuthenticationOptions {
@@ -189,7 +193,13 @@ func NewDelegatingAuthenticationOptions() *DelegatingAuthenticationOptions {
 			GroupHeaders:        []string{"x-remote-group"},
 			ExtraHeaderPrefixes: []string{"x-remote-extra-"},
 		},
+		ClientTimeout: 10 * time.Second,
 	}
+}
+
+// WithClientTimeout sets the given timeout for the authentication webhook client.
+func (s *DelegatingAuthenticationOptions) WithClientTimeout(timeout time.Duration) {
+	s.ClientTimeout = timeout
 }
 
 func (s *DelegatingAuthenticationOptions) Validate() []error {
@@ -377,6 +387,7 @@ func (s *DelegatingAuthenticationOptions) getClient() (kubernetes.Interface, err
 	// set high qps/burst limits since this will effectively limit API server responsiveness
 	clientConfig.QPS = 200
 	clientConfig.Burst = 400
+	clientConfig.Timeout = s.ClientTimeout
 
 	return kubernetes.NewForConfig(clientConfig)
 }

--- a/pkg/server/options/authorization.go
+++ b/pkg/server/options/authorization.go
@@ -59,6 +59,10 @@ type DelegatingAuthorizationOptions struct {
 
 	// AlwaysAllowGroups are groups which are allowed to take any actions.  In kube, this is system:masters.
 	AlwaysAllowGroups []string
+
+	// ClientTimeout specifies a time limit for requests made by SubjectAccessReviews client.
+	// The default value is set to 10 seconds.
+	ClientTimeout time.Duration
 }
 
 func NewDelegatingAuthorizationOptions() *DelegatingAuthorizationOptions {
@@ -66,6 +70,7 @@ func NewDelegatingAuthorizationOptions() *DelegatingAuthorizationOptions {
 		// very low for responsiveness, but high enough to handle storms
 		AllowCacheTTL: 10 * time.Second,
 		DenyCacheTTL:  10 * time.Second,
+		ClientTimeout: 10 * time.Second,
 	}
 }
 
@@ -79,6 +84,11 @@ func (s *DelegatingAuthorizationOptions) WithAlwaysAllowGroups(groups ...string)
 func (s *DelegatingAuthorizationOptions) WithAlwaysAllowPaths(paths ...string) *DelegatingAuthorizationOptions {
 	s.AlwaysAllowPaths = append(s.AlwaysAllowPaths, paths...)
 	return s
+}
+
+// WithClientTimeout sets the given timeout for SAR client used by this authorizer
+func (s *DelegatingAuthorizationOptions) WithClientTimeout(timeout time.Duration) {
+	s.ClientTimeout = timeout
 }
 
 func (s *DelegatingAuthorizationOptions) Validate() []error {
@@ -186,6 +196,7 @@ func (s *DelegatingAuthorizationOptions) getClient() (kubernetes.Interface, erro
 	// set high qps/burst limits since this will effectively limit API server responsiveness
 	clientConfig.QPS = 200
 	clientConfig.Burst = 400
+	clientConfig.Timeout = s.ClientTimeout
 
 	// make the client use protobuf
 	protoConfig := rest.CopyConfig(clientConfig)


### PR DESCRIPTION
- Default timeout (10 s) for the `TokenReview` client (96217)
- Default timeout (10 s0) for the `SubjectAccessReview` client (95725)
- No stack trace of aborted requests in the logs (95002 and 96424)

For openshift-apiserver, oauth-server and oauth-apiserver