### PR TITLE
Openshift apiserver 4.10 kubernetes 1.23.12 rebase

### DIFF
--- a/pkg/admission/plugin/namespace/lifecycle/admission.go
+++ b/pkg/admission/plugin/namespace/lifecycle/admission.go
@@ -54,7 +54,16 @@ const (
 // Register registers a plugin
 func Register(plugins *admission.Plugins) {
 	plugins.Register(PluginName, func(config io.Reader) (admission.Interface, error) {
-		return NewLifecycle(sets.NewString(metav1.NamespaceDefault, metav1.NamespaceSystem, metav1.NamespacePublic))
+		return NewLifecycle(sets.NewString(metav1.NamespaceDefault, metav1.NamespaceSystem, metav1.NamespacePublic,
+			// user specified configuration that cannot be rebuilt
+			"openshift-config",
+			// cluster generated configuration that cannot be rebuilt (etcd encryption keys)
+			"openshift-config-managed",
+			// the CVO which is the root we use to rebuild all the rest
+			"openshift-cluster-version",
+			// contains a namespaced list of all nodes in the cluster (yeah, weird.  they do it for multi-tenant management I think?)
+			"openshift-machine-api",
+		))
 	})
 }
 

--- a/pkg/admission/plugin/namespace/lifecycle/admission.go
+++ b/pkg/admission/plugin/namespace/lifecycle/admission.go
@@ -234,7 +234,13 @@ func (l *Lifecycle) ValidateInitialization() error {
 // accessReviewResources are resources which give a view into permissions in a namespace.  Users must be allowed to create these
 // resources because returning "not found" errors allows someone to search for the "people I'm going to fire in 2017" namespace.
 var accessReviewResources = map[schema.GroupResource]bool{
-	{Group: "authorization.k8s.io", Resource: "localsubjectaccessreviews"}: true,
+	{Group: "authorization.k8s.io", Resource: "localsubjectaccessreviews"}:                            true,
+	schema.GroupResource{Group: "authorization.openshift.io", Resource: "subjectaccessreviews"}:       true,
+	schema.GroupResource{Group: "authorization.openshift.io", Resource: "localsubjectaccessreviews"}:  true,
+	schema.GroupResource{Group: "authorization.openshift.io", Resource: "resourceaccessreviews"}:      true,
+	schema.GroupResource{Group: "authorization.openshift.io", Resource: "localresourceaccessreviews"}: true,
+	schema.GroupResource{Group: "authorization.openshift.io", Resource: "selfsubjectrulesreviews"}:    true,
+	schema.GroupResource{Group: "authorization.openshift.io", Resource: "subjectrulesreviews"}:        true,
 }
 
 func isAccessReview(a admission.Attributes) bool {

--- a/pkg/endpoints/filters/patch_request_deadline.go
+++ b/pkg/endpoints/filters/patch_request_deadline.go
@@ -1,0 +1,58 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package filters
+
+import (
+	"context"
+	"net/http"
+	"time"
+)
+
+// RequestContextWithUpperBoundOrWorkAroundOurBrokenCaseWhereTimeoutWasNotAppliedYet returns
+// a new deadline bound context for the request.
+//
+// If the request context is already setup with a deadline then use the
+// requestTimeoutUpperBound as the upper bound.
+// If the request context is not setup with a deadline then use:
+//  - user specified timeout in the request URI, otherwise
+//  - use the default value in requestTimeoutUpperBound
+func RequestContextWithUpperBoundOrWorkAroundOurBrokenCaseWhereTimeoutWasNotAppliedYet(req *http.Request, requestTimeoutUpperBound time.Duration) (context.Context, context.CancelFunc) {
+	ctx := req.Context()
+	if _, ok := ctx.Deadline(); ok {
+		// the request already has a deadline set, use the parent
+		// context to setup an upper bound deadline.
+		return context.WithTimeout(ctx, requestTimeoutUpperBound)
+	}
+
+	// the request context does not have any deadline set yet, it could be
+	// a long running request that WithRequestDeadline did not apply to.
+	// set an upper bound deadline using the user specified timeout in the
+	// request URI if available, otherwise use the default value.
+	timeout := parseTimeoutWithDefault(req, requestTimeoutUpperBound)
+	return context.WithTimeout(ctx, timeout)
+}
+
+// parseTimeoutWithDefault parses the given HTTP request URL and extracts
+// the timeout query parameter value if specified by the user.
+// If a timeout is not specified it returns the default value specified.
+func parseTimeoutWithDefault(req *http.Request, defaultTimeout time.Duration) time.Duration {
+	userSpecifiedTimeout, ok, _ := parseTimeout(req)
+	if ok && userSpecifiedTimeout > 0 {
+		return userSpecifiedTimeout
+	}
+	return defaultTimeout
+}

--- a/pkg/endpoints/filters/patch_request_deadline_test.go
+++ b/pkg/endpoints/filters/patch_request_deadline_test.go
@@ -1,0 +1,106 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package filters
+
+import (
+	"context"
+	"net/http"
+	"testing"
+	"time"
+)
+
+func TestRequestContextWithUpperBoundOrWorkAroundOurBrokenCaseWhereTimeoutWasNotAppliedYet(t *testing.T) {
+	tests := []struct {
+		name       string
+		url        string
+		context    func(r *http.Request) (context.Context, context.CancelFunc)
+		upperBound time.Duration
+		remaining  time.Duration
+	}{
+		{
+			name: "request context has a bound deadline",
+			url:  "/foo",
+			context: func(r *http.Request) (context.Context, context.CancelFunc) {
+				return context.WithTimeout(r.Context(), time.Minute)
+			},
+			upperBound: 30 * time.Second,
+			remaining:  28 * time.Second, // to account for flakes in unit test
+		},
+		{
+			name: "request context does not have any bound deadline, no user specified timeout",
+			url:  "/foo",
+			context: func(r *http.Request) (context.Context, context.CancelFunc) {
+				return context.WithCancel(r.Context())
+			},
+			upperBound: 30 * time.Second,
+			remaining:  28 * time.Second, // to account for flakes in unit test
+
+		},
+		{
+			name: "request context does not have any bound deadline, user specified timeout is malformed",
+			url:  "/foo?timeout=invalid",
+			context: func(r *http.Request) (context.Context, context.CancelFunc) {
+				return context.WithCancel(r.Context())
+			},
+			upperBound: 30 * time.Second,
+			remaining:  28 * time.Second, // to account for flakes in unit test
+
+		},
+		{
+			name: "request context does not have any bound deadline, user specified timeout is zero",
+			url:  "/foo?timeout=0s",
+			context: func(r *http.Request) (context.Context, context.CancelFunc) {
+				return context.WithCancel(r.Context())
+			},
+			upperBound: 30 * time.Second,
+			remaining:  28 * time.Second, // to account for flakes in unit test
+
+		},
+		{
+			name: "request context does not have any bound deadline, user specified timeout is valid",
+			url:  "/foo?timeout=5m2s",
+			context: func(r *http.Request) (context.Context, context.CancelFunc) {
+				return context.WithCancel(r.Context())
+			},
+			upperBound: time.Minute,
+			remaining:  5 * time.Minute, // to account for flakes in unit test
+
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			req := newRequest(t, test.url)
+
+			parent, parentCancel := test.context(req)
+			defer parentCancel()
+			req = req.WithContext(parent)
+
+			ctx, cancel := RequestContextWithUpperBoundOrWorkAroundOurBrokenCaseWhereTimeoutWasNotAppliedYet(req, test.upperBound)
+			defer cancel()
+
+			deadline, ok := ctx.Deadline()
+			if !ok {
+				t.Errorf("Expected the context to have a deadline, but got: %t", ok)
+			}
+
+			remainingGot := time.Until(deadline)
+			if remainingGot <= test.remaining {
+				t.Errorf("Expected the remaining deadline to be greater, wanted: %s, but got: %s", test.remaining, remainingGot)
+			}
+		})
+	}
+}

--- a/pkg/endpoints/handlers/create.go
+++ b/pkg/endpoints/handlers/create.go
@@ -35,6 +35,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apiserver/pkg/admission"
 	"k8s.io/apiserver/pkg/audit"
+	"k8s.io/apiserver/pkg/endpoints/filters"
 	"k8s.io/apiserver/pkg/endpoints/handlers/fieldmanager"
 	"k8s.io/apiserver/pkg/endpoints/handlers/finisher"
 	"k8s.io/apiserver/pkg/endpoints/handlers/negotiation"
@@ -78,7 +79,7 @@ func createHandler(r rest.NamedCreater, scope *RequestScope, admit admission.Int
 
 		// enforce a timeout of at most requestTimeoutUpperBound (34s) or less if the user-provided
 		// timeout inside the parent context is lower than requestTimeoutUpperBound.
-		ctx, cancel := context.WithTimeout(req.Context(), requestTimeoutUpperBound)
+		ctx, cancel := filters.RequestContextWithUpperBoundOrWorkAroundOurBrokenCaseWhereTimeoutWasNotAppliedYet(req, requestTimeoutUpperBound)
 		defer cancel()
 		outputMediaType, _, err := negotiation.NegotiateOutputMediaType(req, scope.Serializer, scope)
 		if err != nil {

--- a/pkg/endpoints/handlers/delete.go
+++ b/pkg/endpoints/handlers/delete.go
@@ -17,7 +17,6 @@ limitations under the License.
 package handlers
 
 import (
-	"context"
 	"fmt"
 	"net/http"
 	"time"
@@ -33,6 +32,7 @@ import (
 	"k8s.io/apiserver/pkg/admission"
 	"k8s.io/apiserver/pkg/audit"
 	"k8s.io/apiserver/pkg/endpoints/handlers/finisher"
+	"k8s.io/apiserver/pkg/endpoints/filters"
 	"k8s.io/apiserver/pkg/endpoints/handlers/negotiation"
 	"k8s.io/apiserver/pkg/endpoints/request"
 	"k8s.io/apiserver/pkg/features"
@@ -63,7 +63,7 @@ func DeleteResource(r rest.GracefulDeleter, allowsOptions bool, scope *RequestSc
 
 		// enforce a timeout of at most requestTimeoutUpperBound (34s) or less if the user-provided
 		// timeout inside the parent context is lower than requestTimeoutUpperBound.
-		ctx, cancel := context.WithTimeout(req.Context(), requestTimeoutUpperBound)
+		ctx, cancel := filters.RequestContextWithUpperBoundOrWorkAroundOurBrokenCaseWhereTimeoutWasNotAppliedYet(req, requestTimeoutUpperBound)
 		defer cancel()
 
 		ctx = request.WithNamespace(ctx, namespace)
@@ -184,7 +184,7 @@ func DeleteCollection(r rest.CollectionDeleter, checkBody bool, scope *RequestSc
 
 		// enforce a timeout of at most requestTimeoutUpperBound (34s) or less if the user-provided
 		// timeout inside the parent context is lower than requestTimeoutUpperBound.
-		ctx, cancel := context.WithTimeout(req.Context(), requestTimeoutUpperBound)
+		ctx, cancel := filters.RequestContextWithUpperBoundOrWorkAroundOurBrokenCaseWhereTimeoutWasNotAppliedYet(req, requestTimeoutUpperBound)
 		defer cancel()
 
 		ctx = request.WithNamespace(ctx, namespace)

--- a/pkg/endpoints/handlers/patch.go
+++ b/pkg/endpoints/handlers/patch.go
@@ -43,6 +43,7 @@ import (
 	"k8s.io/apiserver/pkg/admission"
 	"k8s.io/apiserver/pkg/audit"
 	"k8s.io/apiserver/pkg/authorization/authorizer"
+	"k8s.io/apiserver/pkg/endpoints/filters"
 	"k8s.io/apiserver/pkg/endpoints/handlers/fieldmanager"
 	"k8s.io/apiserver/pkg/endpoints/handlers/finisher"
 	"k8s.io/apiserver/pkg/endpoints/handlers/negotiation"
@@ -94,7 +95,7 @@ func PatchResource(r rest.Patcher, scope *RequestScope, admit admission.Interfac
 
 		// enforce a timeout of at most requestTimeoutUpperBound (34s) or less if the user-provided
 		// timeout inside the parent context is lower than requestTimeoutUpperBound.
-		ctx, cancel := context.WithTimeout(req.Context(), requestTimeoutUpperBound)
+		ctx, cancel := filters.RequestContextWithUpperBoundOrWorkAroundOurBrokenCaseWhereTimeoutWasNotAppliedYet(req, requestTimeoutUpperBound)
 		defer cancel()
 
 		ctx = request.WithNamespace(ctx, namespace)

--- a/pkg/endpoints/handlers/update.go
+++ b/pkg/endpoints/handlers/update.go
@@ -33,6 +33,7 @@ import (
 	"k8s.io/apiserver/pkg/admission"
 	"k8s.io/apiserver/pkg/audit"
 	"k8s.io/apiserver/pkg/authorization/authorizer"
+	"k8s.io/apiserver/pkg/endpoints/filters"
 	"k8s.io/apiserver/pkg/endpoints/handlers/fieldmanager"
 	"k8s.io/apiserver/pkg/endpoints/handlers/finisher"
 	"k8s.io/apiserver/pkg/endpoints/handlers/negotiation"
@@ -65,7 +66,7 @@ func UpdateResource(r rest.Updater, scope *RequestScope, admit admission.Interfa
 
 		// enforce a timeout of at most requestTimeoutUpperBound (34s) or less if the user-provided
 		// timeout inside the parent context is lower than requestTimeoutUpperBound.
-		ctx, cancel := context.WithTimeout(req.Context(), requestTimeoutUpperBound)
+		ctx, cancel := filters.RequestContextWithUpperBoundOrWorkAroundOurBrokenCaseWhereTimeoutWasNotAppliedYet(req, requestTimeoutUpperBound)
 		defer cancel()
 
 		ctx = request.WithNamespace(ctx, namespace)

--- a/pkg/server/config.go
+++ b/pkg/server/config.go
@@ -987,8 +987,10 @@ func AuthorizeClientBearerToken(loopback *restclient.Config, authn *Authenticati
 	tokenAuthenticator := authenticatorfactory.NewFromTokens(tokens, authn.APIAudiences)
 	authn.Authenticator = authenticatorunion.New(tokenAuthenticator, authn.Authenticator)
 
-	tokenAuthorizer := authorizerfactory.NewPrivilegedGroups(user.SystemPrivilegedGroup)
-	authz.Authorizer = authorizerunion.New(tokenAuthorizer, authz.Authorizer)
+	if !skipSystemMastersAuthorizer {
+		tokenAuthorizer := authorizerfactory.NewPrivilegedGroups(user.SystemPrivilegedGroup)
+		authz.Authorizer = authorizerunion.New(tokenAuthorizer, authz.Authorizer)
+	}
 }
 
 type nullEventSink struct{}

--- a/pkg/server/config.go
+++ b/pkg/server/config.go
@@ -18,8 +18,10 @@ package server
 
 import (
 	"fmt"
+	"io/ioutil"
 	"net"
 	"net/http"
+	"os"
 	goruntime "runtime"
 	"runtime/debug"
 	"sort"
@@ -32,6 +34,7 @@ import (
 	"github.com/google/uuid"
 	"go.opentelemetry.io/otel/trace"
 
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/runtime/serializer"
@@ -67,6 +70,8 @@ import (
 	utilflowcontrol "k8s.io/apiserver/pkg/util/flowcontrol"
 	flowcontrolrequest "k8s.io/apiserver/pkg/util/flowcontrol/request"
 	"k8s.io/client-go/informers"
+	"k8s.io/client-go/kubernetes"
+	v1 "k8s.io/client-go/kubernetes/typed/core/v1"
 	restclient "k8s.io/client-go/rest"
 	"k8s.io/component-base/logs"
 	"k8s.io/klog/v2"
@@ -239,6 +244,9 @@ type Config struct {
 	// rejected with a 429 status code and a 'Retry-After' response.
 	ShutdownSendRetryAfter bool
 
+	// EventSink receives events about the life cycle of the API server, e.g. readiness, serving, signals and termination.
+	EventSink EventSink
+
 	//===========================================================================
 	// values below here are targets for removal
 	//===========================================================================
@@ -257,6 +265,11 @@ type Config struct {
 
 	// StorageVersionManager holds the storage versions of the API resources installed by this server.
 	StorageVersionManager storageversion.Manager
+}
+
+// EventSink allows to create events.
+type EventSink interface {
+	Create(event *corev1.Event) (*corev1.Event, error)
 }
 
 type RecommendedConfig struct {
@@ -531,6 +544,10 @@ func (c *Config) Complete(informers informers.SharedInformerFactory) CompletedCo
 		c.DiscoveryAddresses = discovery.DefaultAddresses{DefaultAddress: c.ExternalAddress}
 	}
 
+	if c.EventSink == nil {
+		c.EventSink = nullEventSink{}
+	}
+
 	AuthorizeClientBearerToken(c.LoopbackClientConfig, &c.Authentication, &c.Authorization)
 
 	if c.RequestInfoResolver == nil {
@@ -558,7 +575,56 @@ func (c *Config) Complete(informers informers.SharedInformerFactory) CompletedCo
 // Complete fills in any fields not set that are required to have valid data and can be derived
 // from other fields. If you're going to `ApplyOptions`, do that first. It's mutating the receiver.
 func (c *RecommendedConfig) Complete() CompletedConfig {
+	if c.ClientConfig != nil {
+		ref, err := eventReference()
+		if err != nil {
+			klog.Warningf("Failed to derive event reference, won't create events: %v", err)
+			c.EventSink = nullEventSink{}
+		} else {
+			ns := ref.Namespace
+			if len(ns) == 0 {
+				ns = "default"
+			}
+			c.EventSink = &v1.EventSinkImpl{
+				Interface: kubernetes.NewForConfigOrDie(c.ClientConfig).CoreV1().Events(ns),
+			}
+		}
+	}
+
 	return c.Config.Complete(c.SharedInformerFactory)
+}
+
+func eventReference() (*corev1.ObjectReference, error) {
+	ns := os.Getenv("POD_NAMESPACE")
+	pod := os.Getenv("POD_NAME")
+	if len(ns) == 0 && len(pod) > 0 {
+		serviceAccountNamespaceFile := "/var/run/secrets/kubernetes.io/serviceaccount/namespace"
+		if _, err := os.Stat(serviceAccountNamespaceFile); err == nil {
+			bs, err := ioutil.ReadFile(serviceAccountNamespaceFile)
+			if err != nil {
+				return nil, err
+			}
+			ns = string(bs)
+		}
+	}
+	if len(ns) == 0 {
+		pod = ""
+		ns = "kube-system"
+	}
+	if len(pod) == 0 {
+		return &corev1.ObjectReference{
+			Kind:       "Namespace",
+			Name:       ns,
+			APIVersion: "v1",
+		}, nil
+	}
+
+	return &corev1.ObjectReference{
+		Kind:       "Pod",
+		Namespace:  ns,
+		Name:       pod,
+		APIVersion: "v1",
+	}, nil
 }
 
 // New creates a new server which logically combines the handling chain with the passed server.
@@ -628,7 +694,16 @@ func (c completedConfig) New(name string, delegationTarget DelegationTarget) (*G
 		Version: c.Version,
 
 		muxAndDiscoveryCompleteSignals: map[string]<-chan struct{}{},
+
+		eventSink: c.EventSink,
 	}
+
+	ref, err := eventReference()
+	if err != nil {
+		klog.Warningf("Failed to derive event reference, won't create events: %v", err)
+		c.EventSink = nullEventSink{}
+	}
+	s.eventRef = ref
 
 	for {
 		if c.JSONPatchMaxCopyBytes <= 0 {
@@ -914,4 +989,10 @@ func AuthorizeClientBearerToken(loopback *restclient.Config, authn *Authenticati
 
 	tokenAuthorizer := authorizerfactory.NewPrivilegedGroups(user.SystemPrivilegedGroup)
 	authz.Authorizer = authorizerunion.New(tokenAuthorizer, authz.Authorizer)
+}
+
+type nullEventSink struct{}
+
+func (nullEventSink) Create(event *corev1.Event) (*corev1.Event, error) {
+	return nil, nil
 }

--- a/pkg/server/genericapiserver.go
+++ b/pkg/server/genericapiserver.go
@@ -19,6 +19,7 @@ package server
 import (
 	"fmt"
 	"net/http"
+	"os"
 	gpath "path"
 	"strings"
 	"sync"
@@ -26,6 +27,7 @@ import (
 
 	systemd "github.com/coreos/go-systemd/v22/daemon"
 
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -233,6 +235,10 @@ type GenericAPIServer struct {
 	// If enabled, after ShutdownDelayDuration elapses, any incoming request is
 	// rejected with a 429 status code and a 'Retry-After' response.
 	ShutdownSendRetryAfter bool
+
+	// EventSink creates events.
+	eventSink EventSink
+	eventRef  *corev1.ObjectReference
 }
 
 // DelegationTarget is an interface which allows for composition of API servers with top level handling that works
@@ -418,7 +424,11 @@ func (s preparedGenericAPIServer) Run(stopCh <-chan struct{}) error {
 		shutdownInitiatedCh.Signal()
 		klog.V(1).InfoS("[graceful-termination] shutdown event", "name", shutdownInitiatedCh.Name())
 
+		s.Eventf(corev1.EventTypeNormal, "TerminationStart", "Received signal to terminate, becoming unready, but keeping serving")
+
 		time.Sleep(s.ShutdownDelayDuration)
+
+		s.Eventf(corev1.EventTypeNormal, "TerminationMinimalShutdownDurationFinished", "The minimal shutdown duration of %v finished", s.ShutdownDelayDuration)
 	}()
 
 	// close socket after delayed stopCh
@@ -454,6 +464,7 @@ func (s preparedGenericAPIServer) Run(stopCh <-chan struct{}) error {
 
 		// wait for the delayed stopCh before closing the handler chain (it rejects everything after Wait has been called).
 		<-delayedStopCh.Signaled()
+		s.Eventf(corev1.EventTypeNormal, "TerminationStoppedServing", "Server has stopped listening")
 
 		// Wait for all requests to finish, which are bounded by the RequestTimeout variable.
 		s.HandlerChainWaitGroup.Wait()
@@ -467,7 +478,9 @@ func (s preparedGenericAPIServer) Run(stopCh <-chan struct{}) error {
 	if err != nil {
 		return err
 	}
+
 	klog.V(1).Info("[graceful-termination] RunPreShutdownHooks has completed")
+	s.Eventf(corev1.EventTypeNormal, "TerminationPreShutdownHooksFinished", "All pre-shutdown hooks have been finished")
 
 	// Wait for all requests in flight to drain, bounded by the RequestTimeout variable.
 	<-drainedCh.Signaled()
@@ -475,6 +488,8 @@ func (s preparedGenericAPIServer) Run(stopCh <-chan struct{}) error {
 	<-stoppedCh
 
 	klog.V(1).Info("[graceful-termination] apiserver is exiting")
+	s.Eventf(corev1.EventTypeNormal, "TerminationGracefulTerminationFinished", "All pending requests processed")
+
 	return nil
 }
 
@@ -749,4 +764,34 @@ func getResourceNamesForGroup(apiPrefix string, apiGroupInfo *APIGroupInfo, path
 	}
 
 	return resourceNames, nil
+}
+
+// Eventf creates an event with the API server as source, either in default namespace against default namespace, or
+// if POD_NAME/NAMESPACE are set against that pod.
+func (s *GenericAPIServer) Eventf(eventType, reason, messageFmt string, args ...interface{}) {
+	t := metav1.Time{Time: time.Now()}
+	host, _ := os.Hostname() // expicitly ignore error. Empty host is fine
+
+	ref := *s.eventRef
+	if len(ref.Namespace) == 0 {
+		ref.Namespace = "default" // TODO: event broadcaster sets event ns to default. We have to match. Odd.
+	}
+
+	e := &corev1.Event{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      fmt.Sprintf("%v.%x", ref.Name, t.UnixNano()),
+			Namespace: ref.Namespace,
+		},
+		InvolvedObject: ref,
+		Reason:         reason,
+		Message:        fmt.Sprintf(messageFmt, args...),
+		Type:           eventType,
+		Source:         corev1.EventSource{Component: "apiserver", Host: host},
+	}
+
+	klog.V(2).Infof("Event(%#v): type: '%v' reason: '%v' %v", e.InvolvedObject, e.Type, e.Reason, e.Message)
+
+	if _, err := s.eventSink.Create(e); err != nil {
+		klog.Warningf("failed to create event %s/%s: %v", e.Namespace, e.Name, err)
+	}
 }

--- a/pkg/server/options/authorization.go
+++ b/pkg/server/options/authorization.go
@@ -239,5 +239,10 @@ func (s *DelegatingAuthorizationOptions) getClient() (kubernetes.Interface, erro
 		clientConfig.Wrap(s.CustomRoundTripperFn)
 	}
 
-	return kubernetes.NewForConfig(clientConfig)
+	// make the client use protobuf
+	protoConfig := rest.CopyConfig(clientConfig)
+	protoConfig.AcceptContentTypes = "application/vnd.kubernetes.protobuf,application/json"
+	protoConfig.ContentType = "application/vnd.kubernetes.protobuf"
+
+	return kubernetes.NewForConfig(protoConfig)
 }

--- a/pkg/server/patch.go
+++ b/pkg/server/patch.go
@@ -1,0 +1,8 @@
+package server
+
+var skipSystemMastersAuthorizer = false
+
+// SkipSystemMastersAuthorizer disable implicitly added system/master authz, and turn it into another authz mode "SystemMasters", to be added via authorization-mode
+func SkipSystemMastersAuthorizer() {
+	skipSystemMastersAuthorizer = true
+}

--- a/pkg/server/patch.go
+++ b/pkg/server/patch.go
@@ -6,3 +6,10 @@ var skipSystemMastersAuthorizer = false
 func SkipSystemMastersAuthorizer() {
 	skipSystemMastersAuthorizer = true
 }
+
+func (s *GenericAPIServer) RemoveOpenAPIData() {
+	if s.Handler != nil && s.Handler.NonGoRestfulMux != nil {
+		s.Handler.NonGoRestfulMux.Unregister("/openapi/v2")
+	}
+	s.openAPIConfig = nil
+}

--- a/pkg/server/routes/openapi.go
+++ b/pkg/server/routes/openapi.go
@@ -36,6 +36,17 @@ type OpenAPI struct {
 
 // Install adds the SwaggerUI webservice to the given mux.
 func (oa OpenAPI) InstallV2(c *restful.Container, mux *mux.PathRecorderMux) (*handler.OpenAPIService, *spec.Swagger) {
+	// we shadow ClustResourceQuotas, RoleBindingRestrictions, and SecurityContextContstraints
+	// with a CRD. This loop removes all CRQ,RBR, SCC paths
+	// from the OpenAPI spec such that they don't conflict with the CRD
+	// apiextensions-apiserver spec during merging.
+	oa.Config.IgnorePrefixes = append(oa.Config.IgnorePrefixes,
+		"/apis/quota.openshift.io/v1/clusterresourcequotas",
+		"/apis/security.openshift.io/v1/securitycontextconstraints",
+		"/apis/authorization.openshift.io/v1/rolebindingrestrictions",
+		"/apis/authorization.openshift.io/v1/namespaces/{namespace}/rolebindingrestrictions",
+		"/apis/authorization.openshift.io/v1/watch/namespaces/{namespace}/rolebindingrestrictions",
+		"/apis/authorization.openshift.io/v1/watch/rolebindingrestrictions")
 	spec, err := builder2.BuildOpenAPISpec(c.RegisteredWebServices(), oa.Config)
 	if err != nil {
 		klog.Fatalf("Failed to build open api spec for root: %v", err)

--- a/pkg/storage/storagebackend/config.go
+++ b/pkg/storage/storagebackend/config.go
@@ -35,7 +35,7 @@ const (
 
 	DefaultCompactInterval      = 5 * time.Minute
 	DefaultDBMetricPollInterval = 30 * time.Second
-	DefaultHealthcheckTimeout   = 2 * time.Second
+	DefaultHealthcheckTimeout   = 10 * time.Second
 )
 
 // TransportConfig holds all connection related info,  i.e. equal TransportConfig means equal servers we talk to.

--- a/pkg/storage/value/encrypt/aes/aes_test.go
+++ b/pkg/storage/value/encrypt/aes/aes_test.go
@@ -364,10 +364,12 @@ func TestRoundTrip(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	/* FIPS disabled
 	aes24block, err := aes.NewCipher([]byte(bytes.Repeat([]byte("b"), 24)))
 	if err != nil {
 		t.Fatal(err)
 	}
+	*/
 	aes32block, err := aes.NewCipher([]byte(bytes.Repeat([]byte("c"), 32)))
 	if err != nil {
 		t.Fatal(err)
@@ -379,7 +381,7 @@ func TestRoundTrip(t *testing.T) {
 		t       value.Transformer
 	}{
 		{name: "GCM 16 byte key", t: NewGCMTransformer(aes16block)},
-		{name: "GCM 24 byte key", t: NewGCMTransformer(aes24block)},
+		// FIPS disabled {name: "GCM 24 byte key", t: NewGCMTransformer(aes24block)},
 		{name: "GCM 32 byte key", t: NewGCMTransformer(aes32block)},
 		{name: "CBC 32 byte key", t: NewCBCTransformer(aes32block)},
 	}

--- a/pkg/storage/value/encrypt/envelope/grpc_service_unix_test.go
+++ b/pkg/storage/value/encrypt/envelope/grpc_service_unix_test.go
@@ -52,6 +52,8 @@ func newEndpoint() *testSocket {
 // Since the Dial to kms-plugin is non-blocking we expect the construction of gRPC service to succeed even when
 // kms-plugin is not yet up - dialing happens in the background.
 func TestKMSPluginLateStart(t *testing.T) {
+	t.Skip("Test is unsuitable for running in a CPU contended environment")
+
 	t.Parallel()
 	callTimeout := 3 * time.Second
 	s := newEndpoint()
@@ -81,6 +83,8 @@ func TestKMSPluginLateStart(t *testing.T) {
 
 // TestTimeout tests behaviour of the kube-apiserver based on the supplied timeout and delayed start of kms-plugin.
 func TestTimeouts(t *testing.T) {
+	t.Skip("Test is unsuitable for running in a CPU contended environment")
+
 	t.Parallel()
 	var testCases = []struct {
 		desc               string
@@ -184,6 +188,8 @@ func TestTimeouts(t *testing.T) {
 
 // TestIntermittentConnectionLoss tests the scenario where the connection with kms-plugin is intermittently lost.
 func TestIntermittentConnectionLoss(t *testing.T) {
+	t.Skip("Test is unsuitable for running in a CPU contended environment")
+
 	t.Parallel()
 	var (
 		wg1        sync.WaitGroup
@@ -271,7 +277,7 @@ func TestUnsupportedVersion(t *testing.T) {
 	}
 	defer f.CleanUp()
 
-	s, err := NewGRPCService(endpoint.endpoint, 1*time.Second)
+	s, err := NewGRPCService(endpoint.endpoint, 20*time.Second)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -285,7 +291,7 @@ func TestUnsupportedVersion(t *testing.T) {
 
 	destroyService(s)
 
-	s, err = NewGRPCService(endpoint.endpoint, 1*time.Second)
+	s, err = NewGRPCService(endpoint.endpoint, 20*time.Second)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -313,7 +319,7 @@ func TestGRPCService(t *testing.T) {
 	defer f.CleanUp()
 
 	// Create the gRPC client service.
-	service, err := NewGRPCService(endpoint.endpoint, 1*time.Second)
+	service, err := NewGRPCService(endpoint.endpoint, 15*time.Second)
 	if err != nil {
 		t.Fatalf("failed to create envelope service, error: %v", err)
 	}
@@ -416,7 +422,7 @@ func TestInvalidConfiguration(t *testing.T) {
 
 	for _, testCase := range invalidConfigs {
 		t.Run(testCase.name, func(t *testing.T) {
-			_, err := NewGRPCService(testCase.endpoint, 1*time.Second)
+			_, err := NewGRPCService(testCase.endpoint, 20*time.Second)
 			if err == nil {
 				t.Fatalf("should fail to create envelope service for %s.", testCase.name)
 			}


### PR DESCRIPTION

- p 968370de UPSTREAM: <carry>: respect user specified timeout for long running requests
- p 45e89ab2 UPSTREAM: <carry>: openshift-apiserver: ignored namespace lifecycle resources
- s bb24b296 UPSTREAM: <carry>: fix filtering out CustomResourceQuota paths from OpenAPI
- p 73334c1d UPSTREAM: <carry>: openshift-apiserver: add RemoveOpenAPIData method to genericapiserver
- p c9324a37 UPSTREAM: <carry>: Bug 1852056: change etcd health check timeout to 10s
- p 0abf32a4 UPSTREAM: <carry>: simplify the authorizer patch to allow the flags to function
- p b5ce4339 UPSTREAM: <carry>: disable AES24, not supported by FIPS
- p f609afc8 UPSTREAM: <carry>: kube-apiserver: add our immortal namespaces directly to admission plugin
- p 4486b0e9 UPSTREAM: <carry>: create termination events
- p 76ba2b76 UPSTREAM: <carry>: filter out CustomResourceQuota paths from OpenAPI
- p 80dd5aa1 UPSTREAM: 74956: apiserver: switch authorization to use protobuf client
- p 28ce273a UPSTREAM: 00000: gRPC tests for encryption envelope are flaky