### PR TITLE
UPSTREAM: <carry>: Don't fix metadata.namespace on project requests.

### DIFF
--- a/pkg/registry/rest/meta.go
+++ b/pkg/registry/rest/meta.go
@@ -77,5 +77,8 @@ func ExpectedNamespaceForResource(requestNamespace string, resource schema.Group
 	if resource.Resource == "namespaces" && resource.Group == "" {
 		return ""
 	}
+	if resource.Resource == "projects" && resource.Group == "project.openshift.io" {
+		return ""
+	}
 	return requestNamespace
 }


### PR DESCRIPTION
If metadata.namespace is empty, apiservers now helpfully update it to the request namespace. Since the request namespace for project requests is the name of the project, and since projects are cluster-scoped, project objects that are modified in this way are invalid.
