### PR TITLE
OCPBUGS-44693: Default-disable ResilientWatchCacheInitialization

### DIFF
--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -388,7 +388,8 @@ var defaultKubernetesFeatureGates = map[featuregate.Feature]featuregate.FeatureS
 
 	RemainingItemCount: {Default: true, PreRelease: featuregate.GA, LockToDefault: true}, // remove in 1.32
 
-	ResilientWatchCacheInitialization: {Default: true, PreRelease: featuregate.Beta},
+	// Disabled temporarily until cause of storage error triggering cache reinitialization during bootstrap is fixed: https://issues.redhat.com/browse/OCPBUGS-45126.
+	ResilientWatchCacheInitialization: {Default: false, PreRelease: featuregate.Beta},
 
 	RetryGenerateName: {Default: true, PreRelease: featuregate.Beta},
 


### PR DESCRIPTION
There's a separate pre-existing issue causing storage layer errors and watch cache re-initialization during cluster bootstrap. With ResilientWatchCacheInitialization enabled, clients (reflectors in particular) are turned away with 429 responses while the watch cache is being repopulated and retry repeatedly. Without this feature, requests hang (consuming priority and fairness "seats") until the watch cache is initialized or they time out. We fail tests when the total number of watch requests during a job exceeds a threshold based on recent historical totals. The systemic 429/retry behavior causes this threshold to be breached. We are temporarily disabling it to reduce noise as it's a symptom and not the cause of the underlying storage errors.
