### PR TITLE
OCPBUGS-44693: Revert "UPSTREAM: <carry>: Default-disable ResilientWatchCacheInitialization

### DIFF
--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -388,8 +388,7 @@ var defaultKubernetesFeatureGates = map[featuregate.Feature]featuregate.FeatureS
 
 	RemainingItemCount: {Default: true, PreRelease: featuregate.GA, LockToDefault: true}, // remove in 1.32
 
-	// Disabled temporarily until cause of storage error triggering cache reinitialization during bootstrap is fixed: https://issues.redhat.com/browse/OCPBUGS-45126.
-	ResilientWatchCacheInitialization: {Default: false, PreRelease: featuregate.Beta},
+	ResilientWatchCacheInitialization: {Default: true, PreRelease: featuregate.Beta},
 
 	RetryGenerateName: {Default: true, PreRelease: featuregate.Beta},
 


### PR DESCRIPTION
reverts https://github.com/openshift/kubernetes-apiserver/pull/61
