### PR TITLE
Update deprecation warning to indicate that removal timelines may change

### DIFF
--- a/pkg/endpoints/deprecation/deprecation.go
+++ b/pkg/endpoints/deprecation/deprecation.go
@@ -119,7 +119,7 @@ func WarningMessage(obj runtime.Object) string {
 	if removed, hasRemovalInfo := obj.(apiLifecycleRemoved); hasRemovalInfo {
 		removedMajor, removedMinor := removed.APILifecycleRemoved()
 		if removedMajor != 0 || removedMinor != 0 {
-			deprecationWarning = deprecationWarning + fmt.Sprintf(", unavailable in v%d.%d+", removedMajor, removedMinor)
+			deprecationWarning = deprecationWarning + fmt.Sprintf(", unavailable no sooner than v%d.%d+", removedMajor, removedMinor)
 		}
 	}
 

--- a/pkg/endpoints/deprecation/deprecation_test.go
+++ b/pkg/endpoints/deprecation/deprecation_test.go
@@ -258,19 +258,19 @@ func TestWarningMessage(t *testing.T) {
 			name: "removed interface, non-zero-value removal version",
 			obj:  &fakeRemovedObject{major: 1, minor: 2, removedMajor: 3, removedMinor: 4},
 			gvk:  schema.GroupVersionKind{Group: "mygroup", Version: "v1", Kind: "MyKind"},
-			want: "mygroup/v1 MyKind is deprecated in v1.2+, unavailable in v3.4+",
+			want: "mygroup/v1 MyKind is deprecated in v1.2+, unavailable no sooner than v3.4+",
 		},
 		{
 			name: "replaced interface, zero-value replacement",
 			obj:  &fakeReplacedObject{major: 1, minor: 2, removedMajor: 3, removedMinor: 4},
 			gvk:  schema.GroupVersionKind{Group: "mygroup", Version: "v1", Kind: "MyKind"},
-			want: "mygroup/v1 MyKind is deprecated in v1.2+, unavailable in v3.4+",
+			want: "mygroup/v1 MyKind is deprecated in v1.2+, unavailable no sooner than v3.4+",
 		},
 		{
 			name: "replaced interface, non-zero-value replacement",
 			obj:  &fakeReplacedObject{major: 1, minor: 2, removedMajor: 3, removedMinor: 4, replacement: schema.GroupVersionKind{Group: "anothergroup", Version: "v2", Kind: "AnotherKind"}},
 			gvk:  schema.GroupVersionKind{Group: "mygroup", Version: "v1", Kind: "MyKind"},
-			want: "mygroup/v1 MyKind is deprecated in v1.2+, unavailable in v3.4+; use anothergroup/v2 AnotherKind",
+			want: "mygroup/v1 MyKind is deprecated in v1.2+, unavailable no sooner than v3.4+; use anothergroup/v2 AnotherKind",
 		},
 	}
 	for _, tt := range tests {


### PR DESCRIPTION
Currently, a warning for removal states an absolute value of unavailable in v4.10000+. We know that we will never hit a 10000 and yet declared that version anyway. As we prepare for a future where we do genuinely think about deprecations and removals, I think we should indicate to users that timelines are adjustable and that we give them a promise of "no sooner than".

This is a small, but perpetual carry, that would change the message to e.g. unavailable no sooner than v6.0+, which gives more flexibility in the wording to allow us to later make a decision to move that to v7.0 or v8.0 etc

We already vendor this fork in the openshift and oauth API servers so this should add no toil apart from an extra carry during o/k rebases
