### PR TITLE
CNTRLPLANE-2516: UPSTREAM: <carry>: patch structured authentication for extensibility

### DIFF
--- a/pkg/apis/apiserver/validation/validation_patch.go
+++ b/pkg/apis/apiserver/validation/validation_patch.go
@@ -1,0 +1,8 @@
+package validation
+
+import "k8s.io/apimachinery/pkg/util/validation/field"
+
+// ValidateCertificateAuthority is an exported wrapper around validateCertificateAuthority
+func ValidateCertificateAuthority(certificateAuthority string, fldPath *field.Path) field.ErrorList {
+	return validateCertificateAuthority(certificateAuthority, fldPath)
+}

--- a/pkg/authentication/cel/compile_patch.go
+++ b/pkg/authentication/cel/compile_patch.go
@@ -1,0 +1,68 @@
+package cel
+
+import (
+	"fmt"
+
+	"github.com/google/cel-go/cel"
+	"k8s.io/apimachinery/pkg/util/version"
+	apiservercel "k8s.io/apiserver/pkg/cel"
+	"k8s.io/apiserver/pkg/cel/environment"
+)
+
+type EnvironmentSet struct {
+	variableName string
+	envOptions   []cel.EnvOption
+	declTypes    []*apiservercel.DeclType
+}
+
+func (es *EnvironmentSet) Build(baseEnv *environment.EnvSet) (*environment.EnvSet, error) {
+	return baseEnv.Extend(environment.VersionedOptions{
+		IntroducedVersion: version.MajorMinor(1, 0),
+		EnvOptions:        es.envOptions,
+		DeclTypes:         es.declTypes,
+	})
+}
+
+// NewEnvironmentSet returns a *EnvironmentSet that is used for configuring an ExtendableCompiler
+// with a new CEL environment variable. The variable name parameter is an arbitrary string
+// representing the new environment variable. It must not be empty.
+func NewEnvironmentSet(variableName string, options []cel.EnvOption, declTypes []*apiservercel.DeclType) *EnvironmentSet {
+	if len(variableName) == 0 {
+		panic("variable name must not be an empty string")
+	}
+
+	return &EnvironmentSet{
+		variableName: variableName,
+		envOptions:   options,
+		declTypes:    declTypes,
+	}
+}
+
+// ExtendableCompiler is an extension of the baseline compiler
+// that allows for extending the capabilities of the baseline compiler.
+type ExtendableCompiler struct {
+	*compiler
+}
+
+func (ec *ExtendableCompiler) Compile(accessor ExpressionAccessor, variableName string) (CompilationResult, error) {
+	return ec.compiler.compile(accessor, variableName)
+}
+
+func NewExtendableCompiler(baseEnv *environment.EnvSet, additionalEnvSets ...*EnvironmentSet) *ExtendableCompiler {
+	compiler := &compiler{
+		varEnvs: mustBuildEnvs(baseEnv),
+	}
+
+	for _, envSet := range additionalEnvSets {
+		builtEnvSet, err := envSet.Build(baseEnv)
+		if err != nil {
+			panic(fmt.Sprintf("building environment set for variable %q: %v", envSet.variableName, err))
+		}
+
+		compiler.varEnvs[envSet.variableName] = builtEnvSet
+	}
+
+	return &ExtendableCompiler{
+		compiler: compiler,
+	}
+}

--- a/pkg/authentication/cel/mapper_patch.go
+++ b/pkg/authentication/cel/mapper_patch.go
@@ -1,0 +1,36 @@
+package cel
+
+import (
+	"context"
+
+	"github.com/google/cel-go/common/types/traits"
+)
+
+type Mapper struct {
+	*mapper
+}
+
+func NewMapper(compilationResults []CompilationResult) *Mapper {
+	return &Mapper{
+		mapper: &mapper{
+			compilationResults: compilationResults,
+		},
+	}
+}
+
+func (m *Mapper) Eval(ctx context.Context, input VarNameActivation) ([]EvaluationResult, error) {
+	return m.mapper.eval(ctx, input.varNameActivation)
+}
+
+type VarNameActivation struct {
+	*varNameActivation
+}
+
+func NewVarNameActivation(name string, value traits.Mapper) VarNameActivation {
+	return VarNameActivation{
+		varNameActivation: &varNameActivation{
+			name: name,
+			value: value,
+		},
+	}
+}

--- a/plugin/pkg/authenticator/token/oidc/oidc.go
+++ b/plugin/pkg/authenticator/token/oidc/oidc.go
@@ -111,6 +111,9 @@ type Options struct {
 
 	// now is used for testing. It defaults to time.Now.
 	now func() time.Time
+
+	ClaimsExpanders                      []ClaimsExpander
+	UnknownCELValueTypesToStringListFunc UnknownCELValueTypesToStringListFunc
 }
 
 // Subset of dynamiccertificates.CAContentProvider that can be used to dynamically load root CAs.
@@ -201,6 +204,9 @@ type jwtAuthenticator struct {
 	requiredClaims map[string]string
 
 	healthCheck atomic.Pointer[errorHolder]
+
+	claimsExpanders                      []ClaimsExpander
+	unknownCELValueTypesToStringListFunc UnknownCELValueTypesToStringListFunc
 }
 
 // idTokenVerifier is a wrapper around oidc.IDTokenVerifier. It uses the oidc.IDTokenVerifier
@@ -391,6 +397,7 @@ func New(lifecycleCtx context.Context, opts Options) (AuthenticatorTokenWithHeal
 	authn := &jwtAuthenticator{
 		jwtAuthenticator: opts.JWTAuthenticator,
 		resolver:         resolver,
+		claimsExpanders:  opts.ClaimsExpanders,
 		celMapper:        celMapper,
 		requiredClaims:   requiredClaims,
 	}
@@ -749,6 +756,10 @@ func (a *jwtAuthenticator) AuthenticateToken(ctx context.Context, token string) 
 		}
 	}
 
+	if err := doClaimsExpansion(ctx, token, c, a.claimsExpanders...); err != nil {
+		return nil, false, fmt.Errorf("oidc: could not expand additional claims: %v", err)
+	}
+
 	var claimsValue *lazy.MapValue
 	// Convert the claims to traits.Mapper so that we can evaluate the CEL expressions
 	// against the claims. This is done once here so that we don't have to convert
@@ -927,7 +938,7 @@ func (a *jwtAuthenticator) getGroups(ctx context.Context, c claims, claimsValue 
 		return nil, fmt.Errorf("oidc: error evaluating group claim expression: %w", err)
 	}
 
-	groups, err := convertCELValueToStringList(evalResult.EvalResult)
+	groups, err := convertCELValueToStringList(evalResult.EvalResult, a.unknownCELValueTypesToStringListFunc)
 	if err != nil {
 		return nil, fmt.Errorf("oidc: error evaluating group claim expression: %w", err)
 	}
@@ -980,7 +991,7 @@ func (a *jwtAuthenticator) getExtra(ctx context.Context, c claims, claimsValue *
 			return nil, fmt.Errorf("oidc: error evaluating extra claim expression: %w", fmt.Errorf("invalid type conversion, expected ExtraMappingCondition"))
 		}
 
-		extraValues, err := convertCELValueToStringList(result.EvalResult)
+		extraValues, err := convertCELValueToStringList(result.EvalResult, a.unknownCELValueTypesToStringListFunc)
 		if err != nil {
 			return nil, fmt.Errorf("oidc: error evaluating extra claim expression: %s: %w", extraMapping.Expression, err)
 		}
@@ -1090,7 +1101,7 @@ func newClaimsValue(c claims) *lazy.MapValue {
 // The CEL value needs to be either a string or a list of strings.
 // "", [] are treated as not being present and will return nil.
 // Empty string in a list of strings is treated as not being present and will be filtered out.
-func convertCELValueToStringList(val ref.Val) ([]string, error) {
+func convertCELValueToStringList(val ref.Val, unknownHandler UnknownCELValueTypesToStringListFunc) ([]string, error) {
 	switch val.Type().TypeName() {
 	case celgo.StringType.TypeName():
 		out := val.Value().(string)
@@ -1136,6 +1147,17 @@ func convertCELValueToStringList(val ref.Val) ([]string, error) {
 	case celgo.NullType.TypeName():
 		return nil, nil
 	default:
+		if unknownHandler != nil {
+			out, ok, err := unknownHandler(val.Value())
+			if ok {
+				if err != nil {
+					return nil, err
+				}
+
+				return out, nil
+			}
+		}
+
 		return nil, fmt.Errorf("expression must return a string or a list of strings")
 	}
 }

--- a/plugin/pkg/authenticator/token/oidc/oidc_patch.go
+++ b/plugin/pkg/authenticator/token/oidc/oidc_patch.go
@@ -1,0 +1,46 @@
+package oidc
+
+import (
+	"context"
+
+	"github.com/google/cel-go/common/types/ref"
+	"github.com/google/cel-go/common/types/traits"
+)
+
+// ClaimsMap is an exported version of the claims type
+type ClaimsMap claims
+
+// ClaimsExpander is used to expand the set of
+// claims made available during the claim-to-identity mapping process.
+type ClaimsExpander interface {
+	ExpandClaims(context.Context, ClaimsMap) error
+}
+
+type tokenContextKey string
+
+const RequestProvidedTokenContextKey tokenContextKey = "authentication.openshift.io/request-provided-token"
+
+func NewClaimsValue(c ClaimsMap) traits.Mapper {
+	return newClaimsValue(claims(c))
+}
+
+type UnknownCELValueTypesToStringListFunc func(val any) ([]string, bool, error)
+
+func ConvertCELValueToStringList(val ref.Val, f UnknownCELValueTypesToStringListFunc) ([]string, error) {
+	return convertCELValueToStringList(val, f)
+}
+
+func doClaimsExpansion(ctx context.Context, token string, clms claims, claimsExpanders ...ClaimsExpander) error {
+	if len(claimsExpanders) == 0 {
+		return nil
+	}
+
+	wrappedCtx := context.WithValue(ctx, RequestProvidedTokenContextKey, token)
+	for _, claimsExpander := range claimsExpanders {
+		if err := claimsExpander.ExpandClaims(wrappedCtx, ClaimsMap(clms)); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}


### PR DESCRIPTION
# Description

This PR adds a patch that wraps/exports currently unexported structured authentication configuration logic and adds an extension point to the OIDC JWT authenticator for us to hook into for extending where we source claims from.

This is part of a multi-PR effort to shift this functionality to the oauth-apiserver so that we can extend it for OpenShift customer use cases that require sourcing claims from sources that are not the token (i.e UserInfo endpoint or Microsoft Graph API).

More information on this feature can be found in the enhancement at https://github.com/openshift/enhancements/blob/master/enhancements/authentication/external-oidc-additional-identity-information-sources.md