### PR TITLE
CNTRLPLANE-2516: UPSTREAM: <carry>: bugfix: wire up unknown CEL value function option

### DIFF
--- a/plugin/pkg/authenticator/token/oidc/oidc.go
+++ b/plugin/pkg/authenticator/token/oidc/oidc.go
@@ -398,6 +398,7 @@ func New(lifecycleCtx context.Context, opts Options) (AuthenticatorTokenWithHeal
 		jwtAuthenticator: opts.JWTAuthenticator,
 		resolver:         resolver,
 		claimsExpanders:  opts.ClaimsExpanders,
+		unknownCELValueTypesToStringListFunc: opts.UnknownCELValueTypesToStringListFunc,
 		celMapper:        celMapper,
 		requiredClaims:   requiredClaims,
 	}
@@ -1136,6 +1137,17 @@ func convertCELValueToStringList(val ref.Val, unknownHandler UnknownCELValueType
 				result = append(result, out)
 			}
 		default:
+			if unknownHandler != nil {
+				out, ok, err := unknownHandler(val.Value())
+				if ok {
+					if err != nil {
+						return nil, err
+					}
+
+					return out, nil
+				}
+			}
+
 			return nil, fmt.Errorf("expression must return a string or a list of strings")
 		}
 


### PR DESCRIPTION
I missed a critical piece of wiring up the unknown CEL value handling behavior in #87 🤦 

This should eventually be rolled up into `UPSTREAM: <carry>: patch structured authentication for extensibility`